### PR TITLE
Add Functional Vilnius to UG list in breadcrumb

### DIFF
--- a/kontaktai.html
+++ b/kontaktai.html
@@ -81,6 +81,7 @@
           <li><a href="http://vilnius-jug.lt">Vilnius JUG</a></li>
                 <li><a href="http://dotnetcrowd.lt">Vilnius .NET</a></li>
           <li><a href="http://vilniusrb.lt">VilniusRB</a></li>
+          <li><a href="http://functionalvilnius.lt" title="Functional Vilnius">Vilnius FP</a></li>
           <li><a href="http://kaunasphp.lt">Kaunas PHP</a></li>
           <li><a href="http://kaunas-jug.lt">Kaunas JUG</a></li>
         </ol>


### PR DESCRIPTION
It would be great to be among the other user groups,
if you don't object.

The official name is "Functional Vilnius", but that would take
up a massive amount of space, so I used an alternative
short-name.